### PR TITLE
Update mac.c

### DIFF
--- a/ath10k/mac.c
+++ b/ath10k/mac.c
@@ -2951,7 +2951,7 @@ static int ath10k_peer_assoc_prepare(struct ath10k *ar,
 
 	ath10k_peer_assoc_h_basic(ar, vif, sta, arg);
 	ath10k_peer_assoc_h_crypto(ar, vif, sta, arg);
-	ath10k_peer_assoc_h_rates(ar, vif, sta, arg);
+	//ath10k_peer_assoc_h_rates(ar, vif, sta, arg);
 	ath10k_peer_assoc_h_ht(ar, vif, sta, arg);
 	ath10k_peer_assoc_h_vht(ar, vif, sta, arg);
 	ath10k_peer_assoc_h_qos(ar, vif, sta, arg);


### PR DESCRIPTION
This helps to reassociate IBSS stations and prevent 48 mbit bitrate stuck In most cases.
Also this does not corrupt a communication with 802.11n devices, connected to AP interface.