### PR TITLE
Reduce default logging in some cases

### DIFF
--- a/ath10k/mac.c
+++ b/ath10k/mac.c
@@ -2329,7 +2329,7 @@ static void ath10k_peer_assoc_h_rate_overrides(struct ath10k *ar,
 	ratemask = arvif->bitrate_mask.control[band].legacy;
 	rates = sband->bitrates;
 
-	ath10k_warn(ar, "band: %d  ratemask: 0x%x  hw-nss: %d dev-id: 0x%x\n",
+	ath10k_dbg(ar, ATH10K_DBG_MAC2, "band: %d  ratemask: 0x%x  hw-nss: %d dev-id: 0x%x\n",
 		    band, ratemask, hw_nss, ar->dev_id);
 
 	arg->has_rate_overrides = true;

--- a/ath10k/txrx.c
+++ b/ath10k/txrx.c
@@ -320,7 +320,7 @@ void ath10k_peer_map_event(struct ath10k_htt *htt,
 		wake_up(&ar->peer_mapping_wq);
 	}
 
-	ath10k_warn(ar, /*ATH10K_DBG_HTT,*/ "htt peer map vdev %d peer %pM id %d\n",
+	ath10k_dbg(ar, ATH10K_DBG_HTT, "htt peer map vdev %d peer %pM id %d\n",
 		   ev->vdev_id, ev->addr, ev->peer_id);
 
 	WARN_ON(ar->peer_map[ev->peer_id] && (ar->peer_map[ev->peer_id] != peer));
@@ -352,7 +352,7 @@ void ath10k_peer_unmap_event(struct ath10k_htt *htt,
 		goto exit;
 	}
 
-	ath10k_warn(ar, /*ATH10K_DBG_HTT,*/ "removing peer, htt peer unmap vdev %d peer %pM id %d\n",
+	ath10k_dbg(ar, ATH10K_DBG_HTT, "removing peer, htt peer unmap vdev %d peer %pM id %d\n",
 		   peer->vdev_id, peer->addr, ev->peer_id);
 
 	ar->peer_map[ev->peer_id] = NULL;


### PR DESCRIPTION
Using ath10k_warn() in some cases generates too many kernel logs in adhoc mode. Use ath10k_dbg() instead in order to control verbosity level.