### PR TITLE
ath10k-ct: Enable AP VLAN on recent CT firmwares for wave-1 models

### DIFF
--- a/ath10k-4.19/mac.c
+++ b/ath10k-4.19/mac.c
@@ -9948,7 +9948,10 @@ int ath10k_mac_register(struct ath10k *ar)
 		goto err_dfs_detector_exit;
 	}
 
-	if (test_bit(WMI_SERVICE_PER_PACKET_SW_ENCRYPT, ar->wmi.svc_map)) {
+	if (test_bit(WMI_SERVICE_PER_PACKET_SW_ENCRYPT, ar->wmi.svc_map) ||
+	    test_bit(ATH10K_FW_FEATURE_CONSUME_BLOCK_ACK_CT, ar->normal_mode_fw.fw_file.fw_features)) {
+			/* assume enough raw tx support for VLAN if a recent CT
+			firmware is detected. */
 		ar->hw->wiphy->interface_modes |= BIT(NL80211_IFTYPE_AP_VLAN);
 		ar->hw->wiphy->software_iftypes |= BIT(NL80211_IFTYPE_AP_VLAN);
 	}


### PR DESCRIPTION
Expect recent CT firmwares, detected by CONSUME_BLOCK_ACK feature, to
support enough raw TX for AP VLAN mode to actually work also on wave1
radios.

This has been tested using recent openwrt 19.07 95d5cbdec34e3d29db17a2c823e3d01be1e9c283 on a TPLink Archer C5 v1 (wave-1 radio).
Actually, I am unsure what tests to run to actually test raw packets (is just transmitting some multicast over the VLAN enough?), anyway, in normal day operation "just using the internet" via different wifis using WPA enterprise and radius assigned dynamic vlans, everything seems fine.