### PR TITLE
ath10k-ct: workaround TX rate code firmware bug

### DIFF
--- a/ath10k-5.4/core.h
+++ b/ath10k-5.4/core.h
@@ -43,6 +43,7 @@
 /* Antenna noise floor */
 #define ATH10K_DEFAULT_NOISE_FLOOR -95
 
+#define ATH10K_CT_TX_BEACON_INVALID_RATE_CODE 0xff
 #define ATH10K_INVALID_RSSI 128
 
 /* This used to be 128, but klukonin reports increasing this helps in at least

--- a/ath10k-5.4/htt_rx.c
+++ b/ath10k-5.4/htt_rx.c
@@ -2813,6 +2813,12 @@ static void ath10k_htt_rx_tx_compl_ind(struct ath10k *ar,
 					    tx_done.mpdus_tried,
 					    tx_done.mpdus_failed);
 
+			/* workaround for possibly firmware bug */
+			if (unlikely(tx_done.tx_rate_code == ATH10K_CT_TX_BEACON_INVALID_RATE_CODE)) {
+				dev_warn_once(ar->dev, "htt tx ct: fixing invalid VHT TX rate code 0xff\n");
+				tx_done.tx_rate_code = 0;
+			}
+
 			/* kfifo_put: In practice firmware shouldn't fire off per-CE
 			 * interrupt and main interrupt (MSI/-X range case) for the same
 			 * HTC service so it should be safe to use kfifo_put w/o lock.
@@ -2900,6 +2906,12 @@ static void ath10k_htt_rx_tx_compl_ind(struct ath10k *ar,
 			/* Firmware reports garbage for ack-rssi if packet was not acked. */
 			if (unlikely(tx_done.status != HTT_TX_COMPL_STATE_ACK))
 				tx_done.ack_rssi = 0;
+
+			/* workaround for possibly firmware bug */
+			if (unlikely(tx_done.tx_rate_code == ATH10K_CT_TX_BEACON_INVALID_RATE_CODE)) {
+				dev_warn_once(ar->dev, "htt tx: fixing invalid VHT TX rate code 0xff\n");
+				tx_done.tx_rate_code = 0;
+			}
 
 			ath10k_txrx_tx_unref(htt, &tx_done);
 		}

--- a/ath10k-5.4/wmi.c
+++ b/ath10k-5.4/wmi.c
@@ -6201,7 +6201,7 @@ static void ath10k_wmi_generic_buffer_eventid(struct ath10k *ar, struct sk_buff 
 static void ath10k_wmi_event_beacon_tx(struct ath10k *ar, struct sk_buff *skb)
 {
 	struct ath10k_vif *arvif;
-	const struct wmi_beacon_tx_event *ev;
+	struct wmi_beacon_tx_event *ev;
 	u32 vdev_id;
 	u32 status;
 
@@ -6220,6 +6220,12 @@ static void ath10k_wmi_event_beacon_tx(struct ath10k *ar, struct sk_buff *skb)
 		   vdev_id, status,
 		   status == 0 ? "OK" : (status == 1 ? "XRETRY" : (status == 2 ? "DROP" : "UNKNOWN")),
 		   ev->mpdus_tried, ev->mpdus_failed, ev->tx_rate_code, ev->tx_rate_flags, ev->tsFlags);
+
+	/* workaround for possibly firmware bug */
+	if (unlikely(ev->tx_rate_code == ATH10K_CT_TX_BEACON_INVALID_RATE_CODE)) {
+		dev_warn_once(ar->dev, "wmi: fixing invalid VHT TX rate code 0xff\n");
+		ev->tx_rate_code = 0;
+	}
 
 	arvif = ath10k_get_arvif(ar, vdev_id);
 	if (!arvif) {


### PR DESCRIPTION
It seems, that we get a bad tx/rx rate from firmware, it is not a real
problem so just check for invalid rate (0xff) and force it to be zero
instead.

Fixes: #117
Ref: https://bugs.openwrt.org/index.php?do=details&task_id=3055