### PR TITLE
Fixup version numbering

### DIFF
--- a/ath10k-5.11/pci.c
+++ b/ath10k-5.11/pci.c
@@ -3881,7 +3881,7 @@ static int __ath10k_pci_probe(struct pci_dev *pdev,
 	int (*pci_hard_reset)(struct ath10k *ar);
 	u32 (*targ_cpu_to_ce_addr)(struct ath10k *ar, u32 addr);
 
-	printk(KERN_INFO "ath10k 5.10 driver, optimized for CT firmware, probing pci device: 0x%x.\n",
+	printk(KERN_INFO "ath10k 5.11 driver, optimized for CT firmware, probing pci device: 0x%x.\n",
 	       pci_dev->device);
 
 	switch (pci_dev->device) {

--- a/ath10k-5.17/pci.c
+++ b/ath10k-5.17/pci.c
@@ -3874,7 +3874,7 @@ static int __ath10k_pci_probe(struct pci_dev *pdev,
 	int (*pci_hard_reset)(struct ath10k *ar);
 	u32 (*targ_cpu_to_ce_addr)(struct ath10k *ar, u32 addr);
 
-	printk(KERN_INFO "ath10k 5.12 driver, optimized for CT firmware, probing pci device: 0x%x.\n",
+	printk(KERN_INFO "ath10k 5.17 driver, optimized for CT firmware, probing pci device: 0x%x.\n",
 	       pci_dev->device);
 
 	switch (pci_dev->device) {

--- a/ath10k-5.19/pci.c
+++ b/ath10k-5.19/pci.c
@@ -3874,7 +3874,7 @@ static int __ath10k_pci_probe(struct pci_dev *pdev,
 	int (*pci_hard_reset)(struct ath10k *ar);
 	u32 (*targ_cpu_to_ce_addr)(struct ath10k *ar, u32 addr);
 
-	printk(KERN_INFO "ath10k 5.12 driver, optimized for CT firmware, probing pci device: 0x%x.\n",
+	printk(KERN_INFO "ath10k 5.19 driver, optimized for CT firmware, probing pci device: 0x%x.\n",
 	       pci_dev->device);
 
 	switch (pci_dev->device) {

--- a/ath10k-5.2/pci.c
+++ b/ath10k-5.2/pci.c
@@ -3852,7 +3852,7 @@ static int __ath10k_pci_probe(struct pci_dev *pdev,
 	int (*pci_hard_reset)(struct ath10k *ar);
 	u32 (*targ_cpu_to_ce_addr)(struct ath10k *ar, u32 addr);
 
-	printk(KERN_INFO "ath10k 5.1 driver, optimized for CT firmware, probing pci device: 0x%x.\n",
+	printk(KERN_INFO "ath10k 5.2 driver, optimized for CT firmware, probing pci device: 0x%x.\n",
 	       pci_dev->device);
 
 	switch (pci_dev->device) {

--- a/ath10k-6.2/pci.c
+++ b/ath10k-6.2/pci.c
@@ -3873,7 +3873,7 @@ static int __ath10k_pci_probe(struct pci_dev *pdev,
 	int (*pci_hard_reset)(struct ath10k *ar);
 	u32 (*targ_cpu_to_ce_addr)(struct ath10k *ar, u32 addr);
 
-	printk(KERN_INFO "ath10k 5.12 driver, optimized for CT firmware, probing pci device: 0x%x.\n",
+	printk(KERN_INFO "ath10k 6.2 driver, optimized for CT firmware, probing pci device: 0x%x.\n",
 	       pci_dev->device);
 
 	switch (pci_dev->device) {

--- a/ath10k-6.4/pci.c
+++ b/ath10k-6.4/pci.c
@@ -3869,7 +3869,7 @@ static int __ath10k_pci_probe(struct pci_dev *pdev,
 	int (*pci_hard_reset)(struct ath10k *ar);
 	u32 (*targ_cpu_to_ce_addr)(struct ath10k *ar, u32 addr);
 
-	printk(KERN_INFO "ath10k 5.12 driver, optimized for CT firmware, probing pci device: 0x%x.\n",
+	printk(KERN_INFO "ath10k 6.4 driver, optimized for CT firmware, probing pci device: 0x%x.\n",
 	       pci_dev->device);
 
 	switch (pci_dev->device) {


### PR DESCRIPTION
Some versions are carrying the wrong version number.

Ex. booting at10k-ct v6.2 shows following print on boot:
[   14.164190] ath10k 5.12 driver, ...

Fix them to match the correct version.